### PR TITLE
fixed 2 bugs in fitness evaluation

### DIFF
--- a/membranesimulation.py
+++ b/membranesimulation.py
@@ -62,7 +62,7 @@ class MembraneSimulation():
 		fillTemplate(simScript, scratch, '_LIGAND GROUP PLACEHOLDER_', 'group				ligand 	type {}:{}\n'.format(3,2+len(self.protein.ligands)))
 		fillTemplate(simScript, scratch, '_NANOPARTICLE GROUP PLACEHOLDER_', 'group				np      type 2:{}\n'.format(2+len(self.protein.ligands)))
 		fillTemplate(simScript, scratch, '_LIGAND MEMBRANE INTERACTIONS PLACEHOLDER_', ligandMembraneInteractions)
-		fillTemplate(simScript, scratch, '_MOLECULAR DYNAMICS DUMP PLACEHOLDER_', 'dump			id all custom {} {} id type x y z'.format(
+		fillTemplate(simScript, scratch, '_MOLECULAR DYNAMICS DUMP PLACEHOLDER_', 'dump			coords all custom {} {} id type x y z\ndump_modify	coords sort id'.format(
 																								self.dumpres, os.path.join(self.outdir, self.outName)))				
 		fillTemplate(simScript, scratch, '_TIMESTEP PLACEHOLDER_', 'timestep       {}'.format(self.timestep))		
 		fillTemplate(simScript, scratch, '_RUNTIME PLACEHOLDER_', 'run            {}'.format(self.run))		

--- a/run.py
+++ b/run.py
@@ -142,6 +142,7 @@ def saveMetrics(lis,filename='out.csv'):
 
 def evaluateNPWrapping(outFilename,runtime):    
     minFit = 1E-8
+    outHeaderSize = 9
     outData = []
     if(not os.path.exists(outFilename)):                                
             return minFit,
@@ -149,10 +150,10 @@ def evaluateNPWrapping(outFilename,runtime):
     with open(outFilename, 'r+') as f:
         lines = f.readlines()        
         for i in range(len(lines)):
-            if str('Timestep: {}'.format(runtime)) in lines[i]:            
-                print(lines[i])                
-                lines[i] = ""
-                break
+            if str('ITEM: TIMESTEP') in lines[i] and str(runtime) in lines[i+1]:                
+                for j in range(outHeaderSize):                    
+                    lines[i + j] = ""
+                break                
             lines[i] = ""
 
         for line in lines:
@@ -161,13 +162,12 @@ def evaluateNPWrapping(outFilename,runtime):
 
     os.remove(outFilename)
 
-    if len(outData)<50:
-        #print str(outData)                     
+    if len(outData)<50:        
         return minFit,    
 
     outVectors = {}
     for line in outData:
-        slist = line.split(",")
+        slist = line.split(",")[1:]
         if(len(slist)<3):            
             return minFit,
         if int(slist[0]) in outVectors:
@@ -190,17 +190,17 @@ def evaluateNPWrapping(outFilename,runtime):
                     m = math.sqrt(xd*xd+yd*yd+zd*zd)                                          
                     if(m<7.0):
                         inrange+=1
-                if(inrange>0):
+                if(inrange>3):
                     magnitudes.append(inrange)
 
-    if len(magnitudes)<1:
+    if len(magnitudes)<1:        
         return minFit,
 
     msum = 0
     for m in magnitudes:
         msum += m
 
-    if(msum == 0):
+    if(msum == 0):        
         return minFit,
 
     return msum,
@@ -249,7 +249,7 @@ def evaluatePyLammps(individual):
 
     return 1,
 
-def runSim(path):
+def runSim(path):    
     return parlammps.runSim(path,NP,TIMEOUT) if MPI else parlammps.runSimSerial(path)
 
 def evaluate(individual):


### PR DESCRIPTION
bug1: free membrane beads leading to fitness of (1,) instead of minfit. fixed by setting min of 3 membrane beads before minfit isn't used. 
bug2: xyz output format (from MD simulations) was changed but the parsing of the output file was not
updated accordingly in fitness eval. parsing has been changed to the new format and updated output format from MD sims to also sort by id. 